### PR TITLE
Feature/dotnet preview7

### DIFF
--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -10,7 +10,7 @@
     <Description>
       A Razor class library for interacting with SweetAlert2.
       Use in Client-sde or Server-side Blazor apps.
-      Currently using SweetAlert2@8.14.0
+      Currently using sweetalert2@8.14.0
     </Description>
     <Copyright>Michael J. Currie</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <Authors>Michael J. Currie</Authors>
     <Company>Currie Technologies</Company>
@@ -27,10 +27,6 @@ Use in Server-side Blazor apps.</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
@@ -40,6 +36,7 @@ Use in Server-side Blazor apps.</Description>
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.0.0-preview7.19365.7" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4-beta1.final" />
   </ItemGroup>
 

--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -10,6 +10,7 @@
     <Description>
       A Razor class library for interacting with SweetAlert2.
       Use in Client-sde or Server-side Blazor apps.
+      Currently using SweetAlert2@8.14.0
     </Description>
     <Copyright>Michael J. Currie</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -2,12 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RazorLangVersion>3.0</RazorLangVersion>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <Authors>Michael J. Currie</Authors>
     <Company>Currie Technologies</Company>
     <Product>Razor.SweetAlert2</Product>
-    <Description>A Razor class library for interacting with SweetAlert2.
-Use in Server-side Blazor apps.</Description>
+    <Description>
+      A Razor class library for interacting with SweetAlert2.
+      Use in Client-sde or Server-side Blazor apps.
+    </Description>
     <Copyright>Michael J. Currie</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Basaingeal/Razor.SweetAlert2</PackageProjectUrl>
@@ -15,10 +18,10 @@ Use in Server-side Blazor apps.</Description>
     <RepositoryUrl>https://github.com/Basaingeal/Razor.SweetAlert2</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Blazor SweetAlert SweetAlert2 JSInterop Server Razor</PackageTags>
-    <PackageReleaseNotes>- Update to SweetAlert2 v8.14.0
-- Add CloseButtonHtml property to SweetAlertOptions
+    <PackageReleaseNotes>
+      - Target .Net Standard
+      - Deprecate CurrieTechnologies.Blazor.SweetAlert2
     </PackageReleaseNotes>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,7 +40,9 @@ Use in Server-side Blazor apps.</Description>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.0.0-preview7.19365.7" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4-beta1.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4-beta1.final" >
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ public void ConfigureServices(IServiceCollection services)
 
 Add this script tag in  your root html file (Likely _Host.cshtml), right under the `<script src="_framework/blazor.server.js"></script>` tag.
 ```html
-<script src="_content/currietechnologiesrazorsweetalert2/sweetalert2.min.js"></script>
+<script src="_content/CurrieTechnologies.Razor.SweetAlert2/sweetAlert2.min.js"></script>
 ```
 
 Inject the SweetAlertService into any Blazor component

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<span style="font-size:x-large">Server-side Blazor</span>
+<span style="font-size:x-large">Blazor</span>
 <br>
 +
 <br>
@@ -23,7 +23,7 @@
 [![Build Status](https://dev.azure.com/michaeljcurrie136/CurrieTechnologies.Blazor/_apis/build/status/Basaingeal.Razor.SweetAlert2?branchName=master)](https://dev.azure.com/michaeljcurrie136/CurrieTechnologies.Blazor/_build/latest?definitionId=16&branchName=master)
 ![Nuget](https://img.shields.io/nuget/v/CurrieTechnologies.Razor.SweetAlert2.svg?style=popout)
 
-## This package is for Server-side Blazor only. For Client-side Blazor use [CurrieTechnologies.Blazor.SweetAlert2](https://github.com/Basaingeal/Blazor.SweetAlert2)
+## This package is now for both Server-side and Client-side Blazor. [CurrieTechnologies.Blazor.SweetAlert2](https://github.com/Basaingeal/Blazor.SweetAlert2) is now deprecated.
 
 ### 🙌 Includes themes from the [Official SweetAlert2 Themes project](https://github.com/sweetalert2/sweetalert2-themes) 🙌
 
@@ -75,7 +75,7 @@ Inject the SweetAlertService into any Blazor component
 // Sample.razor
 @inject SweetAlertService Swal;
 <button class="btn btn-primary"
-		@onclick="@(async () => await Swal.FireAsync("Any fool can use a computer"))">
+		@onclick="(async () => await Swal.FireAsync("Any fool can use a computer"))">
 	Try me!
 </button>
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ steps:
 - task: DotNetCoreInstaller@0
   displayName: 'Installing .NET Core SDK...'
   inputs:
-    version: 3.0.100-preview6-012264
+    version: 3.0.100-preview7-012821
 
 - task: DotNetCoreCLI@2
   displayName: 'Restoring Nuget Packages'

--- a/src/ts/SweetAlert.ts
+++ b/src/ts/SweetAlert.ts
@@ -203,7 +203,7 @@ function setTheme(theme: number): void {
   const styleTag = document.createElement("link");
   styleTag.rel = "stylesheet";
   styleTag.id = tagId;
-  styleTag.href = `_content/currietechnologiesrazorsweetalert2/${fileName}`;
+  styleTag.href = `_content/CurrieTechnologies.Razor.SweetAlert2/${fileName}`;
   styleTag.setAttribute("data-theme-number", theme.toString());
   head.appendChild(styleTag);
 }


### PR DESCRIPTION
Closes https://github.com/Basaingeal/Razor.SweetAlert2/issues/1
Targets .NET Standard so it can be consumed by Client-side Blazor
Upgrade to .net core 3.0-preview 7