### PR TITLE
Release/v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-﻿﻿## Enhancements
-* Bump `sweetalert2` to `8.17.6`
-  * **Bug Fix**: remove superfluous arguments (https://github.com/sweetalert2/sweetalert2/issues/1742) (https://github.com/sweetalert2/sweetalert2/commit/96d8429)
-  * **Bug Fix**: throw warning about unexpected type of customClass (https://github.com/sweetalert2/sweetalert2/issues/1743) (https://github.com/sweetalert2/sweetalert2/commit/102bd03)
+﻿﻿# v1.0 Release! 🎉
+
+All future releases will be following semantic versioning, so expect no breaking public API changes until v2.
+This public API has remained largely unchanged for months now, so I'm confident nothing will need to break until either `sweetalert2@9.0.0`, a new .NET version, or an [issue](https://github.com/Basaingeal/Razor.SweetAlert2/issues) is submitted that suggests better/more inutitive functionality. The stable release of Blazor WebAssembly (in May 2020) could cause a breaking change. We'll see.
+
+New (non-breaking) features from `sweetalert2` will be added in minor releases.
+
+##### Currently utilizing `sweetalert2@8.17.6`
+
+## Breaking Changes
+* Bump `Microsoft.AspNetCore.Components` to `3.0.0`
+* Bump `Microsoft.AspNetCore.Components.Web` to `3.0.0`
+

--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -19,8 +19,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>Blazor SweetAlert SweetAlert2 JSInterop Server Razor</PackageTags>
     <PackageReleaseNotes>
-      - Bump sweetalert2
-      - Target .NET Core 3.0.100-preview9
+      - Target .NET Core 3.0.100
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currietechnologies-razorsweetalert2",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "description": "A Razor class library for interacting with SweetAlert2",
   "scripts": {
     "build": "SET NODE_ENV=production && webpack -p --color",


### PR DESCRIPTION
# v1.0 Release! 🎉

All future releases will be following semantic versioning, so expect no breaking public API changes until v2.
This public API has remained largely unchanged for months now, so I'm confident nothing will need to break until either `sweetalert2@9.0.0`, a new .NET version, or an [issue](https://github.com/Basaingeal/Razor.SweetAlert2/issues) is submitted that suggests better/more inutitive functionality. The stable release of Blazor WebAssembly (in May 2020) could cause a breaking change. We'll see.

New (non-breaking) features from `sweetalert2` will be added in minor releases.

##### Currently utilizing `sweetalert2@8.17.6`

## Breaking Changes
* Bump `Microsoft.AspNetCore.Components` to `3.0.0`
* Bump `Microsoft.AspNetCore.Components.Web` to `3.0.0`

