### PR TITLE
Release/v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
-﻿# v2.3.1
+﻿# v2.3.2
 
-- bump `sweetalert2` to `9.5.4`
+- bump `Microsoft.AspNetCore.Components` to `3.1.1`
+- bump `Microsoft.AspNetCore.Components.Web` to `3.1.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# v2.3.2
+﻿# v2.4.0
 
-- bump `Microsoft.AspNetCore.Components` to `3.1.1`
-- bump `Microsoft.AspNetCore.Components.Web` to `3.1.1`
+- bump `sweetalert2` to `9.6.0`
+- Make `AllowOutsideClick` and `AllowEscapeKey` updatable

--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -9,7 +9,7 @@
     <Description>
       A Razor class library for interacting with SweetAlert2.
       Use in Blazor Server Apps or Blazor WebAssembly Apps.
-      Currently using sweetalert2@9.5.3
+      Currently using sweetalert2@9.6.0
     </Description>
     <Copyright>Michael J. Currie</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -19,8 +19,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>Blazor SweetAlert SweetAlert2 JSInterop Server Razor</PackageTags>
     <PackageReleaseNotes>
-      Bump Microsoft.AspNetCore.Components
-      Bump Microsoft.AspNetCore.Components.Web
+      Bump sweetalert2
+      Make AllowOutsideClick and AllowEscapeKey updatable
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -19,7 +19,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>Blazor SweetAlert SweetAlert2 JSInterop Server Razor</PackageTags>
     <PackageReleaseNotes>
-      Bump sweetalert2
+      Bump Microsoft.AspNetCore.Components
+      Bump Microsoft.AspNetCore.Components.Web
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currietechnologies-razorsweetalert2",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "A Razor class library for interacting with SweetAlert2",
   "scripts": {
     "build": "SET NODE_ENV=production && webpack -p --color",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@sweetalert2/themes": "^3.1.0",
     "core-js": "3.6.4",
-    "sweetalert2": "9.5.4"
+    "sweetalert2": "9.6.0"
   },
   "author": "Michael J. Currie",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currietechnologies-razorsweetalert2",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A Razor class library for interacting with SweetAlert2",
   "scripts": {
     "build": "SET NODE_ENV=production && webpack -p --color",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
     "@babel/preset-env": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
-    "@types/node": "^13.1.6",
+    "@types/node": "^13.1.7",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
     "babel-loader": "^8.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5428,10 +5428,10 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-sweetalert2@9.5.4:
-  version "9.5.4"
-  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-9.5.4.tgz#fcf9306a70ff9dbe2cb867b3bb7e871d854a2979"
-  integrity sha512-9FSmW9mCbRTHyx6Nbtgeb5348pJYNGaBafn3reKe/Zx/gOBgxsRVHj3GQ4VusU/tuqDobKAIHUdUvNdsU3MXPQ==
+sweetalert2@9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-9.6.0.tgz#f6bf966b86a88669dce649595588661c2c8e9ae7"
+  integrity sha512-vX2som2H4ahNbiG+HqnpVf0G+nbiJ03f6kgjgHXgYrH20Lyds4k+DEwGZU8yB2EMGqD+AYwPTKND9bqZWguCJg==
 
 table@^5.2.3:
   version "5.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,10 +807,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*", "@types/node@^13.1.6":
-  version "13.1.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.6.tgz#076028d0b0400be8105b89a0a55550c86684ffec"
-  integrity sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==
+"@types/node@*", "@types/node@^13.1.7":
+  version "13.1.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.7.tgz#db51d28b8dfacfe4fb2d0da88f5eb0a2eca00675"
+  integrity sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg==
 
 "@types/q@^1.5.1":
   version "1.5.2"


### PR DESCRIPTION
# v2.4.0

- bump `sweetalert2` to `9.6.0`
- Make `AllowOutsideClick` and `AllowEscapeKey` updatable
