### PR TITLE
Release/v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
-﻿# v2.4.1
+﻿# v2.5.0
 
-- bump `sweetalert2` to `9.6.1`
+- bump `sweetalert2` to `9.7.0`
+- New options property: `OnDestroy`
+
+From the original PR in the `sweetalert2` repository (https://github.com/sweetalert2/sweetalert2/pull/1872#issue-365026220):
+
+> The difference between `onAfterClose` and `onDestroy` is that `onAfterClose` is called for user interactions only (clicks). `onDestroy` is called always, both for user interactions and popup being closed by another popup.
+
+In my testing, `Swal.CloseAsync()` will trigger both `OnAfterClose` and `OnDestroy`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-﻿# v2.4.0
+﻿# v2.4.1
 
-- bump `sweetalert2` to `9.6.0`
-- Make `AllowOutsideClick` and `AllowEscapeKey` updatable
+- bump `sweetalert2` to `9.6.1`

--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -9,7 +9,7 @@
     <Description>
       A Razor class library for interacting with SweetAlert2.
       Use in Blazor Server Apps or Blazor WebAssembly Apps.
-      Currently using sweetalert2@9.6.1
+      Currently using sweetalert2@9.7.0
     </Description>
     <Copyright>Michael J. Currie</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -20,6 +20,7 @@
     <PackageTags>Blazor SweetAlert SweetAlert2 JSInterop Server Razor</PackageTags>
     <PackageReleaseNotes>
       Bump sweetalert2
+      Add OnDestroy callback
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/CurrieTechnologies.Razor.SweetAlert2.csproj
+++ b/CurrieTechnologies.Razor.SweetAlert2.csproj
@@ -9,7 +9,7 @@
     <Description>
       A Razor class library for interacting with SweetAlert2.
       Use in Blazor Server Apps or Blazor WebAssembly Apps.
-      Currently using sweetalert2@9.6.0
+      Currently using sweetalert2@9.6.1
     </Description>
     <Copyright>Michael J. Currie</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -20,7 +20,6 @@
     <PackageTags>Blazor SweetAlert SweetAlert2 JSInterop Server Razor</PackageTags>
     <PackageReleaseNotes>
       Bump sweetalert2
-      Make AllowOutsideClick and AllowEscapeKey updatable
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/Models/SweetAlertOptionPOCO.cs
+++ b/Models/SweetAlertOptionPOCO.cs
@@ -124,6 +124,8 @@
 
         public bool OnAfterClose { get; set; }
 
+        public bool OnDestroy { get; set; }
+
         public bool OnOpen { get; set; }
 
         public bool OnClose { get; set; }

--- a/Models/SweetAlertOptions.cs
+++ b/Models/SweetAlertOptions.cs
@@ -336,9 +336,14 @@
         public SweetAlertCallback OnBeforeOpen { get; set; }
 
         /// <summary>
-        /// Function to run after modal has been disposed.
+        /// Function to run after popup has been disposed by user interaction (and not by another popup).
         /// </summary>
         public SweetAlertCallback OnAfterClose { get; set; }
+
+        /// <summary>
+        /// Function to run after popup has been destroyed either by user interaction or by another popup.
+        /// </summary>
+        public SweetAlertCallback OnDestroy { get; set; }
 
         /// <summary>
         /// Function to run when modal opens, provides modal DOM element as the first argument.
@@ -436,6 +441,7 @@
                 ProgressStepsDistance = this.ProgressStepsDistance,
                 OnBeforeOpen = this.OnBeforeOpen != null,
                 OnAfterClose = this.OnAfterClose != null,
+                OnDestroy = this.OnDestroy != null,
                 OnOpen = this.OnOpen != null,
                 OnClose = this.OnClose != null,
                 OnRender = this.OnRender != null,

--- a/Services/SweetAlertMixin.cs
+++ b/Services/SweetAlertMixin.cs
@@ -390,6 +390,7 @@
                 ProgressStepsDistance = newSettings.ProgressStepsDistance ?? this.storedOptions.ProgressStepsDistance,
                 OnBeforeOpen = newSettings.OnBeforeOpen ?? this.storedOptions.OnBeforeOpen,
                 OnAfterClose = newSettings.OnAfterClose ?? this.storedOptions.OnAfterClose,
+                OnDestroy = newSettings.OnDestroy ?? this.storedOptions.OnDestroy,
                 OnOpen = newSettings.OnOpen ?? this.storedOptions.OnOpen,
                 OnClose = newSettings.OnClose ?? this.storedOptions.OnClose,
                 OnRender = newSettings.OnRender ?? this.storedOptions.OnRender,

--- a/Services/SweetAlertService.cs
+++ b/Services/SweetAlertService.cs
@@ -33,6 +33,9 @@ namespace CurrieTechnologies.Razor.SweetAlert2
         private static readonly IDictionary<Guid, SweetAlertCallback> OnAfterCloseCallbacks =
             new Dictionary<Guid, SweetAlertCallback>();
 
+        private static readonly IDictionary<Guid, SweetAlertCallback> OnDestroyCallbacks =
+            new Dictionary<Guid, SweetAlertCallback>();
+
         private static readonly IDictionary<Guid, InputValidatorCallback> InputValidatorCallbacks =
             new Dictionary<Guid, InputValidatorCallback>();
 
@@ -175,6 +178,11 @@ namespace CurrieTechnologies.Razor.SweetAlert2
             if (settings.OnAfterClose != null)
             {
                 OnAfterCloseCallbacks.Add(requestId, settings.OnAfterClose);
+            }
+
+            if (settings.OnDestroy != null)
+            {
+                OnDestroyCallbacks.Add(requestId, settings.OnDestroy);
             }
         }
 
@@ -593,6 +601,15 @@ namespace CurrieTechnologies.Razor.SweetAlert2
             var requestIdGuid = Guid.Parse(requestId);
             OnAfterCloseCallbacks.TryGetValue(requestIdGuid, out SweetAlertCallback callback);
             OnAfterCloseCallbacks.Remove(requestIdGuid);
+            await callback.InvokeAsync().ConfigureAwait(false);
+        }
+
+        [JSInvokable]
+        public static async Task ReceiveOnDestroyInput(string requestId)
+        {
+            var requestIdGuid = Guid.Parse(requestId);
+            OnDestroyCallbacks.TryGetValue(requestIdGuid, out SweetAlertCallback callback);
+            OnDestroyCallbacks.Remove(requestIdGuid);
             await callback.InvokeAsync().ConfigureAwait(false);
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currietechnologies-razorsweetalert2",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "A Razor class library for interacting with SweetAlert2",
   "scripts": {
     "build": "SET NODE_ENV=production && webpack -p --color",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@sweetalert2/themes": "^3.1.0",
     "core-js": "3.6.4",
-    "sweetalert2": "9.6.1"
+    "sweetalert2": "9.7.0"
   },
   "author": "Michael J. Currie",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currietechnologies-razorsweetalert2",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A Razor class library for interacting with SweetAlert2",
   "scripts": {
     "build": "SET NODE_ENV=production && webpack -p --color",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@sweetalert2/themes": "^3.1.0",
     "core-js": "3.6.4",
-    "sweetalert2": "9.6.0"
+    "sweetalert2": "9.6.1"
   },
   "author": "Michael J. Currie",
   "private": true,

--- a/src/ts/SimpleSweetAlertOptions.ts
+++ b/src/ts/SimpleSweetAlertOptions.ts
@@ -133,6 +133,8 @@ export default interface SimpleSweetAlertOptions {
 
   onAfterClose: boolean;
 
+  onDestroy: boolean;
+
   onOpen: boolean;
 
   onClose: boolean;

--- a/src/ts/SweetAlert.ts
+++ b/src/ts/SweetAlert.ts
@@ -124,6 +124,10 @@ function dispatchOnAfterClose(requestId: string): void {
   DotNet.invokeMethodAsync(namespace, "ReceiveOnAfterCloseInput", requestId);
 }
 
+function dispatchOnDestroy(requestId: string): void {
+  DotNet.invokeMethodAsync(namespace, "ReceiveOnDestroyInput", requestId);
+}
+
 function cleanSettings(settings: SimpleSweetAlertOptions): SimpleSweetAlertOptions {
   const settingsToReturn: any = settings as any;
   for (const propName in settingsToReturn) {
@@ -169,6 +173,12 @@ function getSwalSettingsFromPoco(
     swalSettings.onAfterClose = (): void => dispatchOnAfterClose(requestId);
   } else {
     delete swalSettings.onAfterClose;
+  }
+
+  if (settings.onDestroy) {
+    swalSettings.onDestroy = (): void => dispatchOnDestroy(requestId);
+  } else {
+    delete swalSettings.onDestroy;
   }
 
   if (settings.onOpen) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5428,10 +5428,10 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-sweetalert2@9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-9.6.0.tgz#f6bf966b86a88669dce649595588661c2c8e9ae7"
-  integrity sha512-vX2som2H4ahNbiG+HqnpVf0G+nbiJ03f6kgjgHXgYrH20Lyds4k+DEwGZU8yB2EMGqD+AYwPTKND9bqZWguCJg==
+sweetalert2@9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-9.6.1.tgz#0f328554f2b9199c2f740a08de537019e4dc8955"
+  integrity sha512-aEKg8s40I+JhyZMIbjv3/l+ExtU8ZutKxxm25gBcfageNyBS3AC3dVdMrB2UScD73oKW/H9Ds9wYCjJRXxe5wg==
 
 table@^5.2.3:
   version "5.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5428,10 +5428,10 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-sweetalert2@9.6.1:
-  version "9.6.1"
-  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-9.6.1.tgz#0f328554f2b9199c2f740a08de537019e4dc8955"
-  integrity sha512-aEKg8s40I+JhyZMIbjv3/l+ExtU8ZutKxxm25gBcfageNyBS3AC3dVdMrB2UScD73oKW/H9Ds9wYCjJRXxe5wg==
+sweetalert2@9.7.0:
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-9.7.0.tgz#4a3c4c9e360169ebcb70c2d648cc47b8f3d6e314"
+  integrity sha512-oGGj9hzl/HFx5I33VQyuYCIr3O1HBpQWB10MGYgzbc/3YWKaViH26U1eqq1N+5wtNlviscRBu+4vhSC/237THw==
 
 table@^5.2.3:
   version "5.4.4"


### PR DESCRIPTION
# v2.5.0

- bump `sweetalert2` to `9.7.0`
- New options property: `OnDestroy`

From the original PR in the `sweetalert2` repository (https://github.com/sweetalert2/sweetalert2/pull/1872#issue-365026220):

> The difference between `onAfterClose` and `onDestroy` is that `onAfterClose` is called for user interactions only (clicks). `onDestroy` is called always, both for user interactions and popup being closed by another popup.

In my testing, `Swal.CloseAsync()` will trigger both `OnAfterClose` and `OnDestroy`.
