### PR TITLE
Feature/fix readonly types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
   "cSpell.words": [
     "currietechnologies",
     "swal"
-  ]
+  ],
+  "typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/src/ts/SweetAlert.ts
+++ b/src/ts/SweetAlert.ts
@@ -144,67 +144,106 @@ function getSwalSettingsFromPoco(
   requestId: string,
   isQueue: boolean
 ): SweetAlertOptions {
-  const swalSettings = (cleanSettings(settings) as
+  let swalSettings = (cleanSettings(settings) as
     | SimpleSweetAlertOptions
     | SweetAlertOptions) as SweetAlertOptions;
 
   if (settings.preConfirm) {
-    swalSettings.preConfirm = isQueue
-      ? (inputValue): Promise<any> => dispatchQueuePreConfirm(requestId, inputValue)
-      : (inputValue): Promise<any> => dispatchPreConfirm(requestId, inputValue);
+    swalSettings = {
+      ...swalSettings,
+      preConfirm: isQueue
+        ? (inputValue): Promise<any> => dispatchQueuePreConfirm(requestId, inputValue)
+        : (inputValue): Promise<any> => dispatchPreConfirm(requestId, inputValue),
+    } as SweetAlertOptions;
   } else {
-    delete swalSettings.preConfirm;
+    const { preConfirm, ...rest } = swalSettings;
+    swalSettings = rest as SweetAlertOptions;
   }
 
   if (settings.inputValidator) {
-    swalSettings.inputValidator = (inputValue): Promise<string> =>
-      dispatchInputValidator(requestId, inputValue);
+    swalSettings = {
+      ...swalSettings,
+      inputValidator: (inputValue): Promise<string> =>
+        dispatchInputValidator(requestId, inputValue),
+    } as SweetAlertOptions;
   } else {
-    delete swalSettings.inputValidator;
+    const { inputValidator, ...rest } = swalSettings;
+    swalSettings = rest as SweetAlertOptions;
   }
 
   if (settings.onBeforeOpen) {
-    swalSettings.onBeforeOpen = (): void => dispatchOnBeforeOpen(requestId);
+    swalSettings = {
+      ...swalSettings,
+      onBeforeOpen: (): void => dispatchOnBeforeOpen(requestId),
+    } as SweetAlertOptions;
   } else {
-    delete swalSettings.onBeforeOpen;
+    const { onBeforeOpen, ...rest } = swalSettings;
+    swalSettings = rest as SweetAlertOptions;
   }
 
   if (settings.onAfterClose) {
-    swalSettings.onAfterClose = (): void => dispatchOnAfterClose(requestId);
+    swalSettings = {
+      ...swalSettings,
+      onAfterClose: (): void => dispatchOnAfterClose(requestId),
+    } as SweetAlertOptions;
   } else {
-    delete swalSettings.onAfterClose;
+    const { onAfterClose, ...rest } = swalSettings;
+    swalSettings = rest as SweetAlertOptions;
   }
 
   if (settings.onDestroy) {
-    swalSettings.onDestroy = (): void => dispatchOnDestroy(requestId);
+    swalSettings = {
+      ...swalSettings,
+      onDestroy: (): void => dispatchOnDestroy(requestId),
+    } as SweetAlertOptions;
   } else {
-    delete swalSettings.onDestroy;
+    const { onDestroy, ...rest } = swalSettings;
+    swalSettings = rest as SweetAlertOptions;
   }
 
   if (settings.onOpen) {
-    swalSettings.onOpen = (): void => dispatchOnOpen(requestId);
+    swalSettings = {
+      ...swalSettings,
+      onOpen: (): void => dispatchOnOpen(requestId),
+    } as SweetAlertOptions;
   } else {
-    delete swalSettings.onOpen;
+    const { onOpen, ...rest } = swalSettings;
+    swalSettings = rest as SweetAlertOptions;
   }
 
   if (settings.onClose) {
-    swalSettings.onClose = (): void => dispatchOnClose(requestId);
+    swalSettings = {
+      ...swalSettings,
+      onClose: (): void => dispatchOnClose(requestId),
+    } as SweetAlertOptions;
   } else {
-    delete swalSettings.onClose;
+    const { onClose, ...rest } = swalSettings;
+    swalSettings = rest as SweetAlertOptions;
   }
 
   if (settings.onRender) {
-    swalSettings.onRender = (): void => dispatchOnRender(requestId);
+    swalSettings = {
+      ...swalSettings,
+      onRender: (): void => dispatchOnRender(requestId),
+    } as SweetAlertOptions;
   } else {
-    delete swalSettings.onRender;
+    const { onRender, ...rest } = swalSettings;
+    swalSettings = rest as SweetAlertOptions;
   }
 
   if (settings.grow === "false") {
-    swalSettings.grow = false;
+    swalSettings = {
+      ...swalSettings,
+      grow: false,
+    } as SweetAlertOptions;
   } else if (settings.grow == null) {
-    delete swalSettings.grow;
+    const { grow, ...rest } = swalSettings;
+    swalSettings = rest as SweetAlertOptions;
   } else {
-    swalSettings.grow = settings.grow;
+    swalSettings = {
+      ...swalSettings,
+      grow: settings.grow,
+    } as SweetAlertOptions;
   }
 
   return swalSettings;

--- a/src/ts/SweetAlert.ts
+++ b/src/ts/SweetAlert.ts
@@ -157,6 +157,7 @@ function getSwalSettingsFromPoco(
         : (inputValue): Promise<any> => dispatchPreConfirm(requestId, inputValue),
     } as SweetAlertOptions;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { preConfirm, ...rest } = swalSettings;
     swalSettings = rest as SweetAlertOptions;
   }
@@ -168,6 +169,7 @@ function getSwalSettingsFromPoco(
         dispatchInputValidator(requestId, inputValue),
     } as SweetAlertOptions;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { inputValidator, ...rest } = swalSettings;
     swalSettings = rest as SweetAlertOptions;
   }
@@ -178,6 +180,7 @@ function getSwalSettingsFromPoco(
       onBeforeOpen: (): void => dispatchOnBeforeOpen(requestId),
     } as SweetAlertOptions;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { onBeforeOpen, ...rest } = swalSettings;
     swalSettings = rest as SweetAlertOptions;
   }
@@ -188,6 +191,7 @@ function getSwalSettingsFromPoco(
       onAfterClose: (): void => dispatchOnAfterClose(requestId),
     } as SweetAlertOptions;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { onAfterClose, ...rest } = swalSettings;
     swalSettings = rest as SweetAlertOptions;
   }
@@ -198,6 +202,7 @@ function getSwalSettingsFromPoco(
       onDestroy: (): void => dispatchOnDestroy(requestId),
     } as SweetAlertOptions;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { onDestroy, ...rest } = swalSettings;
     swalSettings = rest as SweetAlertOptions;
   }
@@ -208,6 +213,7 @@ function getSwalSettingsFromPoco(
       onOpen: (): void => dispatchOnOpen(requestId),
     } as SweetAlertOptions;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { onOpen, ...rest } = swalSettings;
     swalSettings = rest as SweetAlertOptions;
   }
@@ -218,6 +224,7 @@ function getSwalSettingsFromPoco(
       onClose: (): void => dispatchOnClose(requestId),
     } as SweetAlertOptions;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { onClose, ...rest } = swalSettings;
     swalSettings = rest as SweetAlertOptions;
   }
@@ -228,6 +235,7 @@ function getSwalSettingsFromPoco(
       onRender: (): void => dispatchOnRender(requestId),
     } as SweetAlertOptions;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { onRender, ...rest } = swalSettings;
     swalSettings = rest as SweetAlertOptions;
   }
@@ -238,6 +246,7 @@ function getSwalSettingsFromPoco(
       grow: false,
     } as SweetAlertOptions;
   } else if (settings.grow == null) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { grow, ...rest } = swalSettings;
     swalSettings = rest as SweetAlertOptions;
   } else {

--- a/src/ts/SweetAlert.ts
+++ b/src/ts/SweetAlert.ts
@@ -5,6 +5,7 @@ import Swal, {
   SweetAlertResult,
   SweetAlertIcon,
   SweetAlertArrayOptions,
+  SweetAlertUpdatableParameters,
 } from "sweetalert2";
 import SimpleSweetAlertOptions from "./SimpleSweetAlertOptions";
 import SweetAlertQueueResult from "./SweetAlertQueueResult";
@@ -396,7 +397,7 @@ razorSwal.Queue = (
     (optionId, i): SweetAlertOptions => getSwalSettingsFromPoco(steps[i], optionId, true)
   );
 
-  Swal.queue(arrSwalSettings).then((result): void => {
+  Swal.queue(arrSwalSettings).then((result: any): void => {
     dispatchQueueResult(requestId, result);
   });
 };
@@ -504,10 +505,10 @@ razorSwal.DeleteQueueStep = (index: number): void => {
   Swal.deleteQueueStep(index);
 };
 
-razorSwal.IsValidParameter = (paramName: string): boolean => {
+razorSwal.IsValidParameter = (paramName: keyof SweetAlertOptions): boolean => {
   return Swal.isValidParameter(paramName);
 };
 
-razorSwal.IsUpdatableParameter = (paramName: string): boolean => {
+razorSwal.IsUpdatableParameter = (paramName: SweetAlertUpdatableParameters): boolean => {
   return Swal.isUpdatableParameter(paramName);
 };


### PR DESCRIPTION
Handle typescript changes introduced in the SweetAlert2 library.

SweetAlert2 recently made a change to their types that made many options "read-only". This library has to transform a C# POCO into a javascript object with callback functions. As a result, it has to take a `SweetAlertOptions` object and manipulate it a bit. It needs to add methods that hit the JSInterop portion of the Blazor app. 

This rework basically copies and reassigns the options object for every manipulation that's done to it, instead of assigning directly, in order to work with these newly read-only properties.

SweetAlert2 PR where this changed: https://github.com/sweetalert2/sweetalert2/pull/1983