### PR TITLE
convert number strings in width property to numbers

### DIFF
--- a/src/ts/SweetAlert.ts
+++ b/src/ts/SweetAlert.ts
@@ -129,6 +129,10 @@ function dispatchOnDestroy(requestId: string): void {
   DotNet.invokeMethodAsync(namespace, "ReceiveOnDestroyInput", requestId);
 }
 
+function numberStringToNumber(numberString: string): string | number {
+  return isNaN(Number(numberString)) ? numberString : Number(numberString);
+}
+
 function cleanSettings(settings: SimpleSweetAlertOptions): SimpleSweetAlertOptions {
   const settingsToReturn: any = settings as any;
   for (const propName in settingsToReturn) {
@@ -206,6 +210,10 @@ function getSwalSettingsFromPoco(
     delete swalSettings.grow;
   } else {
     swalSettings.grow = settings.grow;
+  }
+
+  if (settings.width) {
+    swalSettings.width = numberStringToNumber(settings.width);
   }
 
   return swalSettings;

--- a/src/ts/SweetAlert.ts
+++ b/src/ts/SweetAlert.ts
@@ -130,7 +130,7 @@ function dispatchOnDestroy(requestId: string): void {
 }
 
 function numberStringToNumber(numberString: string): string | number {
-  return isNaN(Number(numberString)) ? numberString : Number(numberString);
+  return Number.isNaN(Number(numberString)) ? numberString : Number(numberString);
 }
 
 function cleanSettings(settings: SimpleSweetAlertOptions): SimpleSweetAlertOptions {


### PR DESCRIPTION
The SweetAlert JS library's width options handles numbers as if they were pixel length strings. i.e `width: 500` is equivilent to `width: '500px'`. However, this is not equivilent to `width: '500'`. 

Since C# properties can only be one type, the width property is a string which offers the most flexibility. However when interoping with JS, it needs to pass a number to the width property and not a string when the string provided is just a number.

This change causes `Width = "500"` in C# to translate to `width: 500` in JS, and not `width: '500'`.

Closes https://github.com/Basaingeal/Razor.SweetAlert2/issues/768