### PR TITLE
send theme in constructor

### DIFF
--- a/Services/SweetAlertService.cs
+++ b/Services/SweetAlertService.cs
@@ -62,6 +62,13 @@ namespace CurrieTechnologies.Razor.SweetAlert2
             colorSchemeThemes = options.ColorSchemeThemes
                 .Select(kvp => new int[2] { (int)kvp.Key, (int)kvp.Value })
                 .ToArray();
+            
+            SendThemesToJS().ContinueWith(result => {});
+        }
+
+        private async Task SendThemesToJS(){
+            await jSRuntime.InvokeAsync<object>("CurrieTechnologies.Razor.SweetAlert2.SendThemesToJS", (int)theme, colorSchemeThemes)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -81,9 +88,7 @@ namespace CurrieTechnologies.Razor.SweetAlert2
                 requestId,
                 title,
                 message,
-                icon?.ToString(),
-                (int)theme,
-                colorSchemeThemes)
+                icon?.ToString())
                 .ConfigureAwait(false);
             return await tcs.Task.ConfigureAwait(false);
         }
@@ -137,9 +142,7 @@ namespace CurrieTechnologies.Razor.SweetAlert2
             await jSRuntime.InvokeAsync<SweetAlertResult>(
                 "CurrieTechnologies.Razor.SweetAlert2.FireSettings",
                 requestId,
-                settings.ToPOCO(),
-                (int)theme,
-                colorSchemeThemes).ConfigureAwait(false);
+                settings.ToPOCO()).ConfigureAwait(false);
             return await tcs.Task.ConfigureAwait(false);
         }
 
@@ -438,9 +441,7 @@ namespace CurrieTechnologies.Razor.SweetAlert2
                 "CurrieTechnologies.Razor.SweetAlert2.Queue",
                 requestId,
                 tuples.Select(t => t.RequestId).ToArray(),
-                tuples.Select(t => t.Step.ToPOCO()).ToArray(),
-                (int)theme,
-                colorSchemeThemes)
+                tuples.Select(t => t.Step.ToPOCO()).ToArray())
                 .ConfigureAwait(false);
             return await tcs.Task.ConfigureAwait(false);
         }

--- a/src/ts/SweetAlert.ts
+++ b/src/ts/SweetAlert.ts
@@ -322,16 +322,19 @@ domWindow.CurrieTechnologies.Razor.SweetAlert2 =
 
 const razorSwal = domWindow.CurrieTechnologies.Razor.SweetAlert2;
 
+razorSwal.SendThemesToJS = (
+  theme: SweetAlertTheme,
+  colorSchemeThemes: ColorSchemeDictionary
+): void => {
+  setTheme(theme, colorSchemeThemes);
+};
+
 razorSwal.Fire = (
   requestId: string,
   title: string | null,
   message: string | null,
-  icon: SweetAlertIcon | null,
-  theme: number,
-  colorSchemeThemes: ColorSchemeDictionary
+  icon: SweetAlertIcon | null
 ): void => {
-  setTheme(theme, colorSchemeThemes);
-
   const params: SweetAlertArrayOptions = [
     title ?? undefined,
     message ?? undefined,
@@ -342,14 +345,7 @@ razorSwal.Fire = (
   });
 };
 
-razorSwal.FireSettings = (
-  requestId: string,
-  settingsPoco: SimpleSweetAlertOptions,
-  theme: number,
-  colorSchemeThemes: ColorSchemeDictionary
-): void => {
-  setTheme(theme, colorSchemeThemes);
-
+razorSwal.FireSettings = (requestId: string, settingsPoco: SimpleSweetAlertOptions): void => {
   const swalSettings = getSwalSettingsFromPoco(settingsPoco, requestId, false);
 
   Swal.fire(swalSettings).then((result): void => {
@@ -360,12 +356,8 @@ razorSwal.FireSettings = (
 razorSwal.Queue = (
   requestId: string,
   optionIds: string[],
-  steps: SimpleSweetAlertOptions[],
-  theme: number,
-  colorSchemeThemes: ColorSchemeDictionary
+  steps: SimpleSweetAlertOptions[]
 ): void => {
-  setTheme(theme, colorSchemeThemes);
-
   const arrSwalSettings: SweetAlertOptions[] = optionIds.map(
     (optionId, i): SweetAlertOptions => getSwalSettingsFromPoco(steps[i], optionId, true)
   );


### PR DESCRIPTION
Closes https://github.com/Basaingeal/Razor.SweetAlert2/issues/632

There was an issue with the CSS documents loading after the Swal popup appeared, leading to a flickering effect. This was because the stylesheets weren't added to the document until a Fire call was made.

This change sets the stylesheets from the constructor of the SweetAlertService. Now, whenever the service is initialized, the stylesheets will be set appropriately, and the flickering should no longer occur.