### PR TITLE
bypass sweetalert2 protestware

### DIFF
--- a/src/ts/SweetAlert.ts
+++ b/src/ts/SweetAlert.ts
@@ -21,6 +21,11 @@ const namespace = "CurrieTechnologies.Razor.SweetAlert2";
 
 window.Swal = Swal;
 
+// bypass sweetalert2 protestware
+if (document.body.style.pointerEvents === "none") {
+  document.body.style.pointerEvents = "auto";
+}
+
 function getEnumNumber(enumString: Swal.DismissReason): number | undefined {
   switch (enumString) {
     case Swal.DismissReason.cancel:


### PR DESCRIPTION
In sweetalert2 `11.5.0` the author changed the protestware for Russians visiting Russian sites from showing an anti-war pop-up, to disabling the whole site. (https://github.com/sweetalert2/sweetalert2/commit/b101973c6a001fad0c1a88921c4d5e89345e9012)

```js
// Dear russian users visiting russian sites. Let's play a game.
if (typeof window !== 'undefined' && /^ru\b/.test(navigator.language) && location.host.match(/\.(ru|su|xn--p1ai)$/)) {
  document.body.style.pointerEvents = 'none'
}
```

This re-enables pointer events if they have been disabled.