### PR TITLE
update sweetalert2 to 11.6.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@currietechnologies/razorsweetalert2",
       "version": "5.3.0",
       "dependencies": {
-        "@sweetalert2/themes": "^5.0.12",
+        "@sweetalert2/themes": "^5.0.15",
         "core-js": "3.26.1",
-        "sweetalert2": "11.5.0"
+        "sweetalert2": "11.6.10"
       },
       "devDependencies": {
         "@babel/cli": "^7.19.3",
@@ -1981,9 +1981,9 @@
       "dev": true
     },
     "node_modules/@sweetalert2/themes": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@sweetalert2/themes/-/themes-5.0.12.tgz",
-      "integrity": "sha512-pdbIoSM9+PIyt4LRPNwr3awwnOTza4MnBFAtnWvPueQ6x1OmRH8oyeIUvJiCApfIe6dYaB0lUAqzb6Z2HeVJSQ==",
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@sweetalert2/themes/-/themes-5.0.15.tgz",
+      "integrity": "sha512-uGU7CynpjRc3cllTqZEvXiZTpfQ6MN4faG+Tf0VFW81bLysCQm00iHS3NJLZx5STRfxpM5SzqeVXpAzJyTG/WA==",
       "peerDependencies": {
         "sweetalert2": "^11.0.0"
       }
@@ -6014,12 +6014,12 @@
       }
     },
     "node_modules/sweetalert2": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.5.0.tgz",
-      "integrity": "sha512-Ret0s0E8HMvGDkcHXnDVd8j7gijpGpuBhasiVzy+QAv+w0uEdFnjLMCfEOrIzbmVgeqxdzc6weBD0nucRGgKuA==",
+      "version": "11.6.10",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.6.10.tgz",
+      "integrity": "sha512-/tzEmEYqqHVkO6iMfvCFcmaO78un93CdZIhB+DGj9BLMkcuXS8jo2bmYoxjEAryhxsKPqXiWmZNo3gw/qw/ZwQ==",
       "funding": {
         "type": "individual",
-        "url": "https://sweetalert2.github.io/#donations"
+        "url": "https://github.com/sponsors/limonte"
       }
     },
     "node_modules/tapable": {
@@ -7863,9 +7863,9 @@
       "dev": true
     },
     "@sweetalert2/themes": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@sweetalert2/themes/-/themes-5.0.12.tgz",
-      "integrity": "sha512-pdbIoSM9+PIyt4LRPNwr3awwnOTza4MnBFAtnWvPueQ6x1OmRH8oyeIUvJiCApfIe6dYaB0lUAqzb6Z2HeVJSQ==",
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@sweetalert2/themes/-/themes-5.0.15.tgz",
+      "integrity": "sha512-uGU7CynpjRc3cllTqZEvXiZTpfQ6MN4faG+Tf0VFW81bLysCQm00iHS3NJLZx5STRfxpM5SzqeVXpAzJyTG/WA==",
       "requires": {}
     },
     "@trysound/sax": {
@@ -10725,9 +10725,9 @@
       }
     },
     "sweetalert2": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.5.0.tgz",
-      "integrity": "sha512-Ret0s0E8HMvGDkcHXnDVd8j7gijpGpuBhasiVzy+QAv+w0uEdFnjLMCfEOrIzbmVgeqxdzc6weBD0nucRGgKuA=="
+      "version": "11.6.10",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.6.10.tgz",
+      "integrity": "sha512-/tzEmEYqqHVkO6iMfvCFcmaO78un93CdZIhB+DGj9BLMkcuXS8jo2bmYoxjEAryhxsKPqXiWmZNo3gw/qw/ZwQ=="
     },
     "tapable": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@sweetalert2/themes": "^5.0.12",
+    "@sweetalert2/themes": "^5.0.15",
     "core-js": "3.26.1",
-    "sweetalert2": "11.5.0"
+    "sweetalert2": "11.6.10"
   },
   "author": "Michael J. Currie",
   "private": true,

--- a/src/ts/SweetAlert.ts
+++ b/src/ts/SweetAlert.ts
@@ -21,10 +21,7 @@ const namespace = "CurrieTechnologies.Razor.SweetAlert2";
 
 window.Swal = Swal;
 
-// bypass sweetalert2 protestware
-if (document.body.style.pointerEvents === "none") {
-  document.body.style.pointerEvents = "auto";
-}
+disableProtestware();
 
 function getEnumNumber(enumString: Swal.DismissReason): number | undefined {
   switch (enumString) {
@@ -385,7 +382,7 @@ razorSwal.DisableButtons = (): void => {
 };
 
 razorSwal.ShowLoading = (): void => {
-  Swal.showLoading();
+  Swal.showLoading(null);
 };
 
 razorSwal.HideLoading = (): void => {
@@ -455,3 +452,26 @@ razorSwal.IsValidParameter = (paramName: keyof SweetAlertOptions): boolean => {
 razorSwal.IsUpdatableParameter = (paramName: SweetAlertUpdatableParameters): boolean => {
   return Swal.isUpdatableParameter(paramName);
 };
+
+function disableProtestware() {
+  const protestwareObserver = new MutationObserver((mutations) => {
+    mutations.forEach((childListMutation) => {
+      childListMutation.addedNodes.forEach((addedNode) => {
+        if (addedNode.nodeName.toLowerCase() === "audio") {
+          const audioNode = addedNode as HTMLAudioElement;
+          if (audioNode.src === "https://discoveric.ru/upload/anthem/61/61-1.mp3") {
+            protestwareObserver.disconnect();
+            audioNode.remove();
+            if (document.body.style.pointerEvents === "none") {
+              document.body.style.pointerEvents = "auto";
+            }
+            console.debug("SweetAlert2 protestware disabled.");
+            return;
+          }
+        }
+      });
+    });
+  });
+
+  protestwareObserver.observe(document.body, { childList: true });
+}


### PR DESCRIPTION
Includes functionality to neutralize the recently updated protestware.

https://security.snyk.io/vuln/SNYK-JS-SWEETALERT2-2774674
